### PR TITLE
Fix/missing separator external secrets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Problem Statement
+
+What is the problem you're trying to solve?
+
+## Related Issue
+
+Fixes #...
+
+## Proposed Changes
+
+How do you like to solve the issue and why?
+
+## Checklist
+- [ ] Run helm template check
+- [ ] I ensured my PR is ready for review with `make reviewable`

--- a/secrets-standalone/templates/external-secrets.yaml
+++ b/secrets-standalone/templates/external-secrets.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.externalSecret.enabled }}
+---
 apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
@@ -13,7 +14,7 @@ spec:
       auth:
         secretRef:
           connectTokenSecretRef:
-            name: {{ .Values.externalSecret.onepassword.tokenName | default "op-crdentials" }}
+            name: {{ .Values.externalSecret.onepassword.tokenName | default "op-credentials" }}
             key: {{ .Values.externalSecret.onepassword.tokenKey | default "token" }}
             namespace: {{ .Release.Namespace }}
   {{ end }}
@@ -22,11 +23,14 @@ spec:
       vault: {{ .Values.externalSecret.onepassword.vaultName }}
       auth:
         serviceAccountSecretRef:
-          name: {{ .Values.externalSecret.onepassword.tokenName | default "op-crdentials" }}
+          name: {{ .Values.externalSecret.onepassword.tokenName | default "op-credentials" }}
           key: {{ .Values.externalSecret.onepassword.tokenKey | default "token" }}
       integrationInfo: # this is optional and defaulted
         name: integration-info
         version: v1
+  {{ end }}
+  {{ if and .Values.externalSecret.onepassword.connectServer .Values.externalSecret.onepassword.sdk }}
+  {{ fail "Only one of externalSecret.onepassword.connectServer or externalSecret.onepassword.sdk can be enabled at the same time!" }}
   {{ end }}
 {{- /*
 ################## Attention ###############################
@@ -37,6 +41,7 @@ spec:
 # --from-literal=token="<token-here>" -n <namespace-here>
 ############################################################
 */}}
+---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:


### PR DESCRIPTION
## Problem Statement

When `externalSecret.enabled` is set only creates ExternalSecret not SecretStore

## Related Issue

## Proposed Changes

Add a tripple hyphen between SecretStore and ExternalSecret would represent the end of each object's document.

## Checklist
- [x] Run helm template check
- [x] I ensured my PR is ready for review with `make reviewable`
