### PR TITLE
feat(secret-standalone): Add dockerconfigjson

### DIFF
--- a/secrets-standalone/templates/external-secrets.yaml
+++ b/secrets-standalone/templates/external-secrets.yaml
@@ -76,3 +76,29 @@ spec:
           key: {{ $.Values.externalSecret.onepassword.item }}/{{ .name }}
     {{ end }}
 {{ end }}
+
+{{ if .Values.externalSecret.privateRegistry.enabled }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.deployment.name }}-private-registry-secret-fetcher
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: {{ .Values.deployment.name }}-secret-store
+  target:
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: '{"auths":{"registry.volcanly.me":{"username": "{{ "{{" }}.username{{ "}}" }}","password": "{{ "{{" }}.password{{ "}}" }}"}}}'
+  data:
+    - secretKey: username
+      remoteRef:
+        key: {{ $.Values.externalSecret.privateRegistry.onepasswordItem | default "Harbor Robot" }}/username
+    - secretKey: password
+      remoteRef:
+        key: {{ $.Values.externalSecret.privateRegistry.onepasswordItem | default "Harbor Robot" }}/password
+{{ end }}

--- a/secrets-standalone/values.yaml
+++ b/secrets-standalone/values.yaml
@@ -32,6 +32,9 @@ privateRegistry:
 
 externalSecret:
   enabled: false
+  privateRegistry:
+    enabled: false
+    onepasswordItem: ""
   onepassword:
     connectServer: false
     connectHost: ""


### PR DESCRIPTION
## Problem Statement

Having plain text private image secret is not best practice, stores it elsewhere in a secret manager or password manager is best practice.

## Related Issue

https://github.com/svenikea/helm-charts/issues/22#issue-3310393276

## Proposed Changes

In the issue https://github.com/svenikea/helm-charts/issues/22#issue-3310393276

## Checklist
- [ ] Run helm template check
- [ ] I ensured my PR is ready for review with `make reviewable`
