### PR TITLE
chore(secrets-standalone): Add refresh interval

### DIFF
--- a/secrets-standalone/templates/external-secrets.yaml
+++ b/secrets-standalone/templates/external-secrets.yaml
@@ -47,7 +47,7 @@ kind: ExternalSecret
 metadata:
   name: {{ .Values.deployment.name }}-secret-fetcher
 spec:
-  refreshInterval: 1h
+  refreshInterval: {{ .Values.externalSecret.refreshInterval | default "24h" }}
   secretStoreRef:
     kind: SecretStore
     name: {{ .Values.deployment.name }}-secret-store
@@ -101,7 +101,7 @@ kind: ExternalSecret
 metadata:
   name: {{ .Values.deployment.name }}-private-registry-secret-fetcher
 spec:
-  refreshInterval: 1h
+  refreshInterval: {{ .Values.externalSecret.refreshInterval | default "24h" }}
   secretStoreRef:
     kind: SecretStore
     name: {{ .Values.deployment.name }}-secret-store

--- a/secrets-standalone/values.yaml
+++ b/secrets-standalone/values.yaml
@@ -32,6 +32,7 @@ privateRegistry:
 
 externalSecret:
   enabled: false
+  refreshInterval:
   privateRegistry:
     enabled: false
     onepasswordItem: ""


### PR DESCRIPTION
## Problem Statement

This pull request will add a refresh interval to fix the issue with OnePassword SDK api call limit.

## Related Issue

https://github.com/svenikea/helm-charts/issues/29

## Checklist
- [x] Run helm template check
- [x] I ensured my PR is ready for review with `make reviewable`
