### PR TITLE
fix(service): replica and hpa conflict

### DIFF
--- a/service/templates/deployment.yaml
+++ b/service/templates/deployment.yaml
@@ -3,7 +3,11 @@ kind: Deployment
 metadata:
   name: {{ .Values.deployment.name }}
 spec:
+  {{- if and .Values.deployment.scale .Values.hpa.enabled }}
+    {{- fail ".Values.deployment.scale must be null and Values.hpa.enable can't be set to true" }}
+  {{- else if .Values.deployment.scale }}
   replicas: {{ .Values.deployment.scale }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Values.deployment.name }}

--- a/service/values.yaml
+++ b/service/values.yaml
@@ -1,7 +1,7 @@
 # Deployment values
 deployment:
   name:
-  scale: 1
+  scale:
   image:
     name: service
     tag: latest


### PR DESCRIPTION
## Problem Statement

HPA and single deployment conflict when both value is set

## Related Issue

[Issue-47](https://github.com/svenikea/helm-charts/issues/47)

## Proposed Changes

* If `hpa.enabled` and `deployment.scale` is set it should print out error saying either one of them is accepted.

## Checklist
- [x] Run helm template check
