### PR TITLE
feat(gateway-api): gateway api

### DIFF
--- a/gateway-api/Chart.yaml
+++ b/gateway-api/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: gateway-api
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/gateway-api/templates/_helpers.tpl
+++ b/gateway-api/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+=========================================================
+ GATEWAY PROVIDER
+=========================================================
+Returns: "traefik", "kong"
+---------------------------------------------------------
+*/}}
+{{/* HTTP Listener Name */}}
+{{- define "gw.httpListenerName" }}
+{{- if .Values.gateway.traefik.enabled }}web
+{{- else }}{{ .Values.gateway.httpListener | default "http" }}
+{{- end }}
+{{- end }}
+{{/* HTTPS Listener Name */}}
+{{- define "gw.httpsListenerName" }}
+{{- if .Values.gateway.traefik.enabled }}websecure
+{{- else }}
+{{- .Values.gateway.httpsListener | default "https" }}
+{{- end }}
+{{- end }}
+
+{{/* HTTP Listener Port */}}
+{{- define "gw.httpListenerPort" }}
+{{- if .Values.gateway.traefik.enabled }}8000
+{{- else }}
+{{- .Values.gateway.httpListenerPort | default 80 }}
+{{- end }}
+{{- end }}
+{{/* HTTPS Listener Port */}}
+{{- define "gw.httpsListenerPort" }}
+{{- if .Values.gateway.traefik.enabled }}8443
+{{- else }}
+{{- .Values.gateway.httpsListenerPort | default 443 }}
+{{- end }}
+{{- end }}
+{{/*
+=========================================================
+ HTTPRoute
+=========================================================
+*/}}
+{{- define "httpRoute.buildFilters" }}
+{{- $name := .Values.deployment.name }}
+{{- .Values.gateway.rules | toYaml }}
+  filters:
+{{- /* CORS Middleware */}}
+{{- if and .Values.gateway.traefik.enabled .Values.gateway.cors.enabled }}
+    - type: ExtensionRef
+      extensionRef:
+        group: traefik.io
+        kind: Middleware
+        name: {{ printf "%s-cors" $name }}
+{{- end -}}
+{{/* Custom Headers */}}
+{{- if .Values.gateway.customHeaders }}
+{{- /* Traefik middleware custom header*/}}
+    - type: ExtensionRef
+      extensionRef:
+        group: traefik.io
+        kind: Middleware
+        name: {{ printf "%s-custom-headers" $name }}
+{{- end -}}
+{{- end -}}

--- a/gateway-api/templates/cert-issuer.yaml
+++ b/gateway-api/templates/cert-issuer.yaml
@@ -1,0 +1,29 @@
+{{ if .Values.certManager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ printf "%s-issuer" .Values.deployment.name }}
+  namespace: {{ .Values.certManager.namespace }}
+spec:
+  acme:
+    email: {{ .Values.certManager.email }}
+    server: {{ .Values.certManager.customIssuerServer | default "https://acme-v02.api.letsencrypt.org/directory" }}
+    privateKeySecretRef:
+      name: {{ .Values.certManager.privateKeySecretRef }}
+    solvers:
+    {{- if .Values.certManager.http01.enabled }}
+      - http01:
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: {{ printf "%s-gateway" .Values.deployment.name | default "default" }}
+                namespace: {{ .Release.Namespace }}
+                kind: Gateway
+    {{- end }}
+    {{- if .Values.certManager.dns01.cloudflare.enabled }}
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: {{ .Values.certManager.dns01.cloudflare.apiTokenSecretName }}
+              key: {{ .Values.certManager.dns01.cloudflare.apiTokenSecretKey }}
+    {{- end }}
+{{ end }}

--- a/gateway-api/templates/gateway.yaml
+++ b/gateway-api/templates/gateway.yaml
@@ -1,0 +1,78 @@
+{{- $traefik := .Values.gateway.traefik.enabled }}
+{{- if .Values.gateway.customGateway.enabled }}
+{{- if .Values.gateway.hostName }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ printf "%s-gateway" .Values.deployment.name | default "default" }}
+  annotations:
+    {{- if .Values.certManager.enabled }}
+    cert-manager.io/issuer: {{ printf "%s-issuer" .Values.deployment.name }}
+    {{- end }}
+    {{- if .Values.gateway.annotations }}
+    {{- .Values.gateway.annotations | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  {{- /*https://github.com/istio/istio/discussions/52904*/}}
+  addresses:
+  {{- if .Values.gateway.sharedIPAddress }}
+  - value: {{ .Values.gateway.sharedIPAddress }}
+    type: IPAddress
+  {{- end }}
+  gatewayClassName: {{ .Values.gateway.gatewayClassName | default "gateway-api" }}
+  listeners:
+  - name: {{ include "gw.httpListenerName" . }}
+    protocol: HTTP
+    port: {{ include "gw.httpListenerPort" . }}
+    hostname: {{ .Values.gateway.hostName }}
+  {{- if .Values.gateway.httpRoute.sslRedirect.enabled }}
+  - name: {{ include "gw.httpsListenerName" . }}
+    protocol: HTTPS
+    port: {{ include "gw.httpsListenerPort" . }}
+    hostname: {{ .Values.gateway.hostName }}
+    tls:
+      certificateRefs:
+        - name: {{ printf "%s-issuer" .Values.deployment.name }}
+      mode: {{ .Values.gateway.tlsMode }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- if .Values.gateway.hostNames }}
+{{- range $index, $host := $.Values.gateway.hostNames }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ printf "%s-gateway-%d" $.Values.deployment.name ($index | add1) | default "default" }}
+  annotations:
+    {{- if $.Values.certManager.enabled }}
+    cert-manager.io/issuer: {{ printf "%s-issuer" $.Values.deployment.name }}
+    {{- end }}
+    {{- if $.Values.gateway.annotations }}
+    {{- $.Values.gateway.annotations | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  {{- /*https://github.com/istio/istio/discussions/52904*/}}
+  addresses:
+  {{- if $.Values.gateway.sharedIPAddress }}
+  - value: {{ $.Values.gateway.sharedIPAddress }}
+    type: IPAddress
+  {{- end }}
+  gatewayClassName: {{ $.Values.gateway.gatewayClassName | default "gateway-api" }}
+  listeners:
+  - name: {{ include "gw.httpListenerName" $ }}
+    protocol: HTTP
+    port: {{ include "gw.httpListenerPort" $ }}
+    hostname: {{ $host }}
+  {{- if $.Values.gateway.httpRoute.sslRedirect.enabled }}
+  - name: {{ include "gw.httpsListenerName" $ }}
+    protocol: HTTPS
+    port: {{ include "gw.httpsListenerPort" $ }}
+    hostname: {{ $host }}
+    tls:
+      certificateRefs:
+        - name: {{ printf "%s-issuer" $.Values.deployment.name }}
+      mode: {{ $.Values.gateway.tlsMode }}
+  {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/gateway-api/templates/httproute.yaml
+++ b/gateway-api/templates/httproute.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.gateway.httpRoute.enabled }}
+{{- $traefik := .Values.gateway.traefik.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ printf "%s-http" .Values.deployment.name }}
+spec:
+  parentRefs:
+    - name: {{ if .Values.gateway.customGateway.enabled }}{{ printf "%s-gateway" .Values.deployment.name | default "default" }}{{ else }}{{ .Values.gateway.name }}{{ end }}
+      {{- if .Values.gateway.httpListener }}
+      sectionName: {{ .Values.gateway.httpListener }}
+      {{- else }}
+      sectionName: {{ include "gw.httpListenerName" . }}
+      {{- end }}
+      {{- if .Values.gateway.httpRoute.namespace }}
+      namespace: {{ .Values.gateway.httpRoute.namespace | default .Release.Namespace }}
+      {{- end }}
+  {{- if .Values.gateway.hostName }}
+  hostnames:
+    - {{ .Values.gateway.hostName | quote }}
+  {{- end }}
+  {{- if .Values.gateway.hostNames }}
+  hostnames:
+  {{- .Values.gateway.hostNames | toYaml | nindent 4 }}
+  {{- end }}
+  rules:
+  {{- if .Values.gateway.httpRoute.sslRedirect.enabled }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+  {{- else }}
+  {{- include "httpRoute.buildFilters" .  | nindent 4 }}
+  {{- end }}
+{{- if .Values.gateway.httpRoute.sslRedirect.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ printf "%s-https" .Values.deployment.name }}
+spec:
+  parentRefs:
+    - name: {{ if .Values.gateway.customGateway.enabled }}{{ printf "%s-gateway" .Values.deployment.name | default "default" }}{{ else }}{{ .Values.gateway.name }}{{ end }}
+      {{- if .Values.gateway.httpsListener }}
+      sectionName: {{ .Values.gateway.httpsListener }}
+      {{- else }}
+      sectionName: {{ include "gw.httpsListenerName" . }}
+      {{- end }}
+      {{- if .Values.gateway.httpRoute.namespace }}
+      namespace: {{ .Values.gateway.httpRoute.namespace | default .Release.Namespace }}
+      {{- end }}
+  {{- if .Values.gateway.hostName }}
+  hostnames:
+    - {{ .Values.gateway.hostName | quote }}
+  {{- end }}
+  {{- if .Values.gateway.hostNames }}
+  hostnames:
+  {{- .Values.gateway.hostNames | toYaml | nindent 4 }}
+  {{- end }}
+  rules: {{- include "httpRoute.buildFilters" . | nindent 4 }}
+{{ end }}
+{{ end }}

--- a/gateway-api/templates/middlewares.yaml
+++ b/gateway-api/templates/middlewares.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.gateway.traefik.enabled .Values.gateway.cors.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ printf "%s-cors" .Values.deployment.name }}
+spec:
+  headers:
+    accessControlAllowMethods:
+    {{- .Values.gateway.cors.methodLists | toYaml | nindent 6 }}
+    accessControlAllowHeaders:
+      - "*"
+    accessControlAllowOriginList:
+    {{- .Values.gateway.cors.originLists | toYaml | nindent 6 }}
+    accessControlMaxAge: 100
+    addVaryHeader: true
+{{- end }}
+{{- if and .Values.gateway.traefik.enabled .Values.gateway.customHeaders }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ printf "%s-custom-headers" .Values.deployment.name }}
+spec:
+  headers:
+    {{- toYaml .Values.gateway.customHeaders | nindent 4 }}
+{{- end }}

--- a/gateway-api/values.yaml
+++ b/gateway-api/values.yaml
@@ -1,0 +1,47 @@
+deployment:
+  name:
+gateway:
+  httpsListener:
+  httpsListenerPort:
+  httpListener:
+  httpListenerPort:
+  customHeaders:
+  cors:
+    enabled: false
+    originLists:
+    methodLists:
+      - "GET"
+      - "OPTIONS"
+      - "PUT"
+      - "POST"
+  traefik:
+    enabled: false
+  httpRoute:
+    enabled: false
+    namespace:
+    sslRedirect:
+      enabled: false
+  customGateway:
+    enabled: false
+  gatewayName:
+  sharedIPAddress:
+  annotations:
+  gatewayClassName:
+  hostName:
+  hostNames:
+  tlsMode:
+  rules:
+
+certManager:
+  enabled: false
+  namespace:
+  email:
+  customIssuerServer:
+  privateKeySecretRef:
+  http01:
+    enabled: false
+  dns01:
+    cloudflare:
+      enabled: false
+      apiTokenSecretName:
+      apiTokenSecretKey:


### PR DESCRIPTION
## Problem Statement

As of right now, ingress-nginx is set to [retire](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/) in March 2026 due to a lack of maintainership and increasing security concerns

## Related Issue

[issue-39](https://github.com/svenikea/helm-charts/issues/39)

## Proposed Changes

Add initial gateway api with traefik controller integration. Other controller will be supported in the future

## Checklist
- [x] Run helm template check
- [x] I ensured my PR is ready for review with `make reviewable`
